### PR TITLE
Optimize CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,4 +21,4 @@ jobs:
     - name: Setup Gradle and execute teamcode build
       uses: gradle/gradle-build-action@v2
       with:
-        arguments: teamcode:build
+        arguments: teamcode:compileReleaseSources

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,3 +5,6 @@ android.useAndroidX=true
 
 # Automatically convert third-party libraries to use AndroidX
 android.enableJetifier=true
+
+# Enable build caching
+org.gradle.caching=true


### PR DESCRIPTION
Should cut down CI build times from ~2 minutes to ~1 minute
Also enables Gradle caching for non-CI builds, but Android Studio seems to have been overriding that anyway.